### PR TITLE
Feature/tildeequal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,16 @@ to use the commandline:
 min_python_version = 3.6.2
 ```
 
-if a `>=` is set for `python_requires` in `setup.cfg`, that value will be used:
+if a `>=` or `~=` is set for `python_requires` in `setup.cfg`, that value will be used:
 
 ```ini
 # setup.cfg setuptools metadata
 
 [options]
 python_requires = >=3.6
+
+[options]
+python_requires = ~=3.6
 ```
 
 ## as a pre-commit hook

--- a/flake8_typing_imports.py
+++ b/flake8_typing_imports.py
@@ -556,7 +556,7 @@ class Plugin:
         v = cls._min_python_version
         for part in cfg['options']['python_requires'].split(','):
             part = part.strip()
-            if part.startswith('>='):
+            if part.startswith('>=') or part.startswith('~='):
                 v = Version.parse(part[2:])
 
         v = max(v, SYMBOLS[0][0])

--- a/tests/flake8_typing_imports_test.py
+++ b/tests/flake8_typing_imports_test.py
@@ -31,6 +31,10 @@ def test_option_parsing_python_requires_setup_cfg(tmpdir):
     Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
     assert Plugin._min_python_version == Version(3, 6, 0)
 
+def test_option_parsing_python_requires_setup_cfg_tildeequal(tmpdir):
+    tmpdir.join('setup.cfg').write('[options]\npython_requires = ~=3.6')
+    Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
+    assert Plugin._min_python_version == Version(3, 6, 0)
 
 def test_option_parsing_python_requires_more_complicated(tmpdir):
     tmpdir.join('setup.cfg').write(

--- a/tests/flake8_typing_imports_test.py
+++ b/tests/flake8_typing_imports_test.py
@@ -31,10 +31,12 @@ def test_option_parsing_python_requires_setup_cfg(tmpdir):
     Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
     assert Plugin._min_python_version == Version(3, 6, 0)
 
+
 def test_option_parsing_python_requires_setup_cfg_tildeequal(tmpdir):
     tmpdir.join('setup.cfg').write('[options]\npython_requires = ~=3.6')
     Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
     assert Plugin._min_python_version == Version(3, 6, 0)
+
 
 def test_option_parsing_python_requires_more_complicated(tmpdir):
     tmpdir.join('setup.cfg').write(


### PR DESCRIPTION
I like to configure the version in setup.cfg like `~=3.6` instead of `>=3.6, <4`.

I added support with version definition with '~='. I also added a corresponding test and updated the README.