### PR TITLE
 Support reading the minimum Python version from pyproject.toml

### DIFF
--- a/flake8_typing_imports.py
+++ b/flake8_typing_imports.py
@@ -12,6 +12,8 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 
+import toml
+
 if sys.version_info < (3, 8):  # pragma: no cover (<PY38)
     import importlib_metadata
 else:  # pragma: no cover (PY38+)
@@ -926,6 +928,8 @@ class Plugin:
 
         if os.path.exists('setup.cfg'):
             cfg.read('setup.cfg')
+        elif os.path.exists('pyproject.toml'):
+            cls._parse_pyproject_toml(cfg)
 
         v = cls._min_python_version
         for part in cfg['options']['python_requires'].split(','):
@@ -937,6 +941,14 @@ class Plugin:
         if v not in VERSIONS:
             raise ValueError(f'min-python-version ({v}): unknown version')
         cls._min_python_version = v
+
+    @classmethod
+    def _parse_pyproject_toml(cls, cfg: configparser.ConfigParser) -> None:
+        with open('pyproject.toml', encoding='UTF-8') as fp:
+            pp_config = toml.load(fp).get('project', {})
+
+        if 'requires-python' in pp_config:
+            cfg['options']['python_requires'] = pp_config['requires-python']
 
     def __init__(self, tree: ast.AST):
         self._tree = tree

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 [options]
 py_modules = flake8_typing_imports
 install_requires =
+    toml>=0.10.2
     flake8>=3.7
     importlib-metadata>=0.9;python_version<"3.8"
 python_requires = >=3.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,8 @@ classifiers =
 [options]
 py_modules = flake8_typing_imports
 install_requires =
-    toml>=0.10.2
     flake8>=3.7
+    toml>=0.10.2
     importlib-metadata>=0.9;python_version<"3.8"
 python_requires = >=3.6.1
 

--- a/tests/flake8_typing_imports_test.py
+++ b/tests/flake8_typing_imports_test.py
@@ -41,6 +41,30 @@ def test_option_parsing_python_requires_more_complicated(tmpdir):
     assert Plugin._min_python_version == Version(3, 5, 0)
 
 
+def test_option_parsing_python_requires_pyproject_toml(tmpdir):
+    tmpdir.join('pyproject.toml').write('[project]\nrequires-python = ">=3.6"')
+    Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
+    assert Plugin._min_python_version == Version(3, 6, 0)
+
+
+def test_option_parsing_python_requires_pyproject_toml_dynamic(tmpdir):
+    tmpdir.join('pyproject.toml').write(
+        '[project]\n'
+        'dynamic = ["requires-python"]',
+    )
+    Plugin.parse_options(mock.Mock(min_python_version='3.5.0'))
+    assert Plugin._min_python_version == Version(3, 5, 0)
+
+
+def test_option_parsing_python_requires_pyproject_complicated(tmpdir):
+    tmpdir.join('pyproject.toml').write(
+        '[project]\n'
+        'requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"',
+    )
+    Plugin.parse_options(mock.Mock(min_python_version='3.6.0'))
+    assert Plugin._min_python_version == Version(3, 5, 0)
+
+
 def test_option_parsing_minimum_version():
     Plugin.parse_options(mock.Mock(min_python_version='3.4'))
     assert Plugin._min_python_version == Version(3, 5, 0)


### PR DESCRIPTION
[PEP 621 -- Storing project metadata in pyproject.toml](https://www.python.org/dev/peps/pep-0621/) defined a new way of defining static metadata in `pyproject.toml`, including the minimum supported python version, as an alternative and eventual replacement for `setup.cfg`. This PR will allow the minimum python version to be parsed from `pyproject.toml` instead.
