### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -33,7 +33,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.0
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39]
+    toxenvs: [py37, py38, py39]
     os: linux

--- a/bin/build-generated
+++ b/bin/build-generated
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import json
 import re
 import subprocess
 from typing import Any
-from typing import Dict
-from typing import Set
-from typing import Tuple
 
 TAG_RE = re.compile(r'^v[0-9.]+$')
 
 
-def get_tag_list(repo: str) -> Tuple[str, ...]:
+def get_tag_list(repo: str) -> tuple[str, ...]:
     subprocess.check_call(('git', '-C', repo, 'fetch', '-q', '--tags'))
     out = subprocess.check_output(('git', '-C', repo, 'tag', '--list'))
     return tuple(out.decode().splitlines())
@@ -39,7 +38,7 @@ print(json.dumps([
 '''
 
 
-def get_defined_names(v: Tuple[int, ...], s: bytes) -> Set[str]:
+def get_defined_names(v: tuple[int, ...], s: bytes) -> set[str]:
     """The __all__ of typing is very unreliable: bpo-36983"""
     proc = subprocess.run(
         (f'python{v[0]}.{v[1]}', '-c', PROG),
@@ -55,9 +54,9 @@ def get_defined_names(v: Tuple[int, ...], s: bytes) -> Set[str]:
 
 
 def compare(old: str, new: str) -> None:
-    old_dct: Dict[str, Any] = {'Version': lambda *a: a}
+    old_dct: dict[str, Any] = {'Version': lambda *a: a}
     exec(old, old_dct)
-    new_dct: Dict[str, Any] = {'Version': lambda *a: a}
+    new_dct: dict[str, Any] = {'Version': lambda *a: a}
     exec(new, new_dct)
     for (v, k_old), (_, k_new) in zip(old_dct['SYMBOLS'], new_dct['SYMBOLS']):
         print(str(v).center(79, '='))

--- a/flake8_typing_imports.py
+++ b/flake8_typing_imports.py
@@ -1,16 +1,13 @@
+from __future__ import annotations
+
 import ast
 import collections
 import configparser
 import os.path
 import sys
 from typing import Any
-from typing import Dict
 from typing import Generator
-from typing import List
 from typing import NamedTuple
-from typing import Set
-from typing import Tuple
-from typing import Type
 
 if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
     import importlib.metadata as importlib_metadata
@@ -38,7 +35,7 @@ class Version(NamedTuple):
         return f'{self.major}.{self.minor}.{self.patch}'
 
     @classmethod
-    def parse(cls, s: str) -> 'Version':
+    def parse(cls, s: str) -> Version:
         return cls(*(int(p) for p in s.split('.')))
 
 
@@ -1213,18 +1210,18 @@ VERSIONS = frozenset(version for version, _ in SYMBOLS)
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self._level = -1
-        self.imports: Dict[str, List[Tuple[int, int]]]
+        self.imports: dict[str, list[tuple[int, int]]]
         self.imports = collections.defaultdict(list)
-        self.attributes: Dict[str, List[Tuple[int, int]]]
+        self.attributes: dict[str, list[tuple[int, int]]]
         self.attributes = collections.defaultdict(list)
         self.defined_overload = False
-        self.unions_pattern_or_match: List[Tuple[int, int]] = []
-        self.from_imported_names: Set[str] = set()
+        self.unions_pattern_or_match: list[tuple[int, int]] = []
+        self.from_imported_names: set[str] = set()
         self._in_namedtuple = False
-        self.namedtuple_methods: List[Tuple[int, int]] = []
-        self.namedtuple_defaults: List[Tuple[int, int]] = []
+        self.namedtuple_methods: list[tuple[int, int]] = []
+        self.namedtuple_defaults: list[tuple[int, int]] = []
 
-    def _is_typing(self, node: ast.AST, names: Tuple[str, ...]) -> bool:
+    def _is_typing(self, node: ast.AST, names: tuple[str, ...]) -> bool:
         return (
             isinstance(node, ast.Name) and
             node.id in names and
@@ -1338,9 +1335,9 @@ class Plugin:
     def _version_specific_errors(
             self,
             msg: str,
-            name_positions: Dict[str, List[Tuple[int, int]]],
-    ) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
-        error_versions: Dict[Tuple[int, int, str], List[Version]]
+            name_positions: dict[str, list[tuple[int, int]]],
+    ) -> Generator[tuple[int, int, str, type[Any]], None, None]:
+        error_versions: dict[tuple[int, int, str], list[Version]]
         error_versions = collections.defaultdict(list)
 
         for version, symbols in SYMBOLS:
@@ -1354,7 +1351,7 @@ class Plugin:
             versions_s = ', '.join(str(v) for v in versions)
             yield line, col, msg.format(k, versions_s), type(self)
 
-    def run(self) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
+    def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]:
         visitor = Visitor()
         visitor.visit(self._tree)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ py_modules = flake8_typing_imports
 install_requires =
     flake8>=3.8
     importlib-metadata>=0.9;python_version<"3.8"
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 flake8.extension =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/flake8_typing_imports_test.py
+++ b/tests/flake8_typing_imports_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 from unittest import mock
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,pypy3,pre-commit
+envlist = py37,py38,py39,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos